### PR TITLE
fix: removed drf-yasg

### DIFF
--- a/eCommerce/eCommerce/settings.py
+++ b/eCommerce/eCommerce/settings.py
@@ -39,7 +39,7 @@ INSTALLED_APPS = [
     'rest_framework_simplejwt.token_blacklist',
     'corsheaders',
     'django_filters',
-    'drf_yasg',
+    'drf_spectacular',
     
     # Local apps
     'healthcheck',
@@ -138,6 +138,15 @@ REST_FRAMEWORK = {
     ],
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
     'PAGE_SIZE': 12,
+    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
+}
+
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'eCommerce API',
+    'DESCRIPTION': 'A comprehensive API for the eCommerce platform.',
+    'VERSION': '1.0.0',
+    'SERVE_INCLUDE_SCHEMA': False,
+    'COMPONENT_SPLIT_REQUEST': True,
 }
 
 SIMPLE_JWT = {
@@ -156,19 +165,6 @@ SIMPLE_JWT = {
     'USER_ID_CLAIM': 'user_id',
     'AUTH_TOKEN_CLASSES': ('rest_framework_simplejwt.tokens.AccessToken',),
     'TOKEN_TYPE_CLAIM': 'token_type',
-}
-
-# API Documentation Settings
-SWAGGER_SETTINGS = {
-   'SECURITY_DEFINITIONS': {
-      'Bearer': {
-            'type': 'apiKey',
-            'name': 'Authorization',
-            'in': 'header'
-      }
-   },
-   'LOGIN_URL': 'rest_framework:login',
-   'LOGOUT_URL': 'rest_framework:logout',
 }
 
 # Email Configuration

--- a/eCommerce/eCommerce/urls.py
+++ b/eCommerce/eCommerce/urls.py
@@ -5,24 +5,9 @@ from django.contrib import admin
 from django.urls import path, include
 from django.conf import settings
 from django.conf.urls.static import static
-from rest_framework import permissions
-from drf_yasg.views import get_schema_view
-from drf_yasg import openapi
+from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
 from users.views import CustomTokenObtainPairView
 from rest_framework_simplejwt.views import TokenRefreshView
-
-# A simplified schema_view configuration for maximum stability.
-schema_view = get_schema_view(
-   openapi.Info(
-      title="E-Commerce API",
-      default_version='v1',
-      description="API documentation for the E-Commerce backend project.",
-      contact=openapi.Contact(email="sibandallen@gmail.com"),
-      license=openapi.License(name="BSD License"),
-   ),
-   public=True,
-   permission_classes=(permissions.AllowAny,),
-)
 
 urlpatterns = [
     path('admin/', admin.site.urls),
@@ -37,9 +22,11 @@ urlpatterns = [
     path('api/v1/token/', CustomTokenObtainPairView.as_view(), name='token_obtain_pair'),
     path('api/v1/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
 
-    # API Documentation
-    path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
-    path('redoc/', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
+    # API Documentation with drf-spectacular
+    path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
+    # Optional UI:
+    path('api/swagger-ui/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
+    path('api/redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
 ]
 
 # Serve media files during development

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ django-filter==25.2
 djangorestframework==3.16.1
 djangorestframework_simplejwt==5.5.1
 drf-spectacular==0.29.0
-drf-yasg==1.21.11
 gunicorn==22.0.0
 inflection==0.5.1
 jsonschema==4.25.1
@@ -26,3 +25,4 @@ rpds-py==0.29.0
 requests==2.32.3
 sqlparse==0.5.3
 uritemplate==4.2.0
+drf-yasg==1.21.11


### PR DESCRIPTION
replaced drf-yasg with drf-spectacular

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated API documentation infrastructure. API documentation endpoints have been reorganized and are now accessible at `/api/schema/`, `/api/swagger-ui/`, and `/api/redoc/` (previously at `/swagger/` and `/redoc/`).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->